### PR TITLE
IGT sync, clean-up and bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Splinter Cell: Chaos Theory Autoplitter
+
+## Memory addresses
+
+| Binary            | OS1        | OS2   | OS3  | OS4  | Type   | Name            | Description                                                                      |
+| ----------------- | ---------- | ----- | ---- | ---- | ------ | --------------- | -------------------------------------------------------------------------------- |
+| splintercell3.exe | 0x00A0E3DC | 0x8   | 0x94 |      | bool   | inMenu          | `true` while the ESC menu is open                                                |
+| binkw32.dll       | 0x54AB4    |       |      |      | bool   | cutscene        | `true` while a cutscene is running                                               |
+| splintercell3.exe | 0x9327E8   |       |      |      | bool   | qsql            | `true` while quick-loading or quick-saving                                       |
+| splintercell3.exe | 0x8C8B38   |       |      |      | int    | isLoading       | `1` while loading a level or in the main menu                                    |
+| splintercell3.exe | 0x73E6CC   | 0x4   |      |      | string | mapName         | Map name                                                                         |
+| splintercell3.exe | 0xA17608   | 0x184 |      |      | int    | inResetMenu     | Momentarily goes to `0` in the "PRESS ANY KEY TO CONTINUE" screen for Lighthouse |
+| splintercell3.exe | 0x0090B734 | 0x10  | 0x14 | 0x80 | double | igt             | In-game timer                                                                    |
+| splintercell3.exe | 0xA2C81C   |       |      |      | bool   | missionComplete | `true` when the "MISSION COMPLETE" screen is up                                  |
+| splintercell3.exe | 0x7497D4   | 0x1C  |      |      | bool   | soshoEnd        | Mission complete flag in Kokubo Sosho                                            |
+| splintercell3.exe | 0x008FA4E8 | 0xE8  |      |      | bool   | missionEnd      | `true` during "MISSION COMPLETE" or "MISSION FAILED" screens                     |
+
+## Map names
+
+These are the internal map names that you get when you read the memory address mentioned above. They are also the file names of the files in Data/Maps/.
+
+### Singleplayer
+
+| Map          | Internal name  |
+| ------------ | -------------- |
+| Main menu    | menu           |
+| Lighthouse   | 01_Lighthouse  |
+| Cargo ship   | 02_CargoShip   |
+| Bank         | 03_Bank        |
+| Penthouse    | 04_Penthouse   |
+| Displace     | 05_Displace    |
+| Hokkaido     | 06_Hokkaido    |
+| Battery      | 07_Battery     |
+| Seoul 1      | 08_SeoulOne    |
+| Seoul 2      | 09_SeoulTwo    |
+| Bathhouse    | 10_Bathhouse   |
+| Kokubo Sosho | 11_KokuboSosho |
+
+### Co-op
+
+| Map             | Internal name    |
+| --------------- | ---------------- |
+| Training        | 00_Training_COOP |
+| Panama          | 01_Panama        |
+| Seoul 3         | 02_seoulthree    |
+| Chemical Bunker | 03_ChemBunker    |
+| Train Station   | 04_GCS           |
+| UN Headquarters | 07_UNhq          |
+| Nuclear Plant   | 05_NuclearPlant  |

--- a/SCCT_AutoSplitter.asl
+++ b/SCCT_AutoSplitter.asl
@@ -3,37 +3,40 @@
 // Please leave some feedback on how well the autosplitter works and report bugs to Distro.
 
 state("splintercell3")
-{	
+{
     //Load Removal
     bool isMenu: "splintercell3.exe", 0x8FA4E8, 0xF8; // Flag that tells you when we're in the menu. Only necessary if you use either LevelTime or LoadTime. Can also be used in the future if we want to pause the timer in menus.
-    bool cutscene: "binkw32.dll", 0x54AB4; // Flag that tells you when a cutscene is running. Only necessary if you use either LevelTime or LoadTime.   
+    bool cutscene: "binkw32.dll", 0x54AB4; // Flag that tells you when a cutscene is running. Only necessary if you use either LevelTime or LoadTime.
     //int loadSave: "splintercell3.exe", 0x29A560, 0xC, 0x134; // set to 6 during QS or QL
     int loadSave: "splintercell3.exe", 0xA16A08, 0xC, 0x134; // set to 6 during QS or QL
     int levelLoad: "splintercell3.exe", 0x8C8B38; // used as flag because the value stays at 1 when loading a level.
 
     //Splitting behavior
-	string255 map: "splintercell3.exe", 0x73E6CC, 0x4; 
-	int ResetMenu: "splintercell3.exe",  0xA17608, 0x184; // Used for auto-reset. Turns to 0 when Press Fire to Load Screen is done loading on Lighthouse.
+    string255 map: "splintercell3.exe", 0x73E6CC, 0x4;
+    int ResetMenu: "splintercell3.exe",  0xA17608, 0x184; // Used for auto-reset. Turns to 0 when Press Fire to Load Screen is done loading on Lighthouse.
     //int runStart: "splintercell3.exe",  0x1079F4, 0x94; // Used for auto-start. Jumps from 1 to 49155 or 49166 when run starts.
-	int runStart: "splintercell3.exe",  0x8F6988, 0x450, 0x9C, 0x10, 0x50, 0x820; // Used for auto-start. Jumps from 1 to 49155 or 49166 when run starts.
+    int runStart: "splintercell3.exe",  0x8F6988, 0x450, 0x9C, 0x10, 0x50, 0x820; // Used for auto-start. Jumps from 1 to 49155 or 49166 when run starts.
     bool soshoEnd: "splintercell3.exe",  0x7497D4, 0x1C; // Last mission complete Flag 1
     //bool missionComplete: "splintercell3.exe", 0xA2C81C; // 1 at mission complete
 }
 
-startup {
+startup
+{
     settings.Add("subsplit", false, "Split when entering Seoul Part 2?");
 }
 
-isLoading {
+isLoading
+{
     return (current.loadSave == 6 || current.levelLoad == 1);
 }
 
-start {
-	return (current.runStart == 49155 || current.runStart == 49156 || current.runStart == 49166);
+start
+{
+    return (current.runStart == 49155 || current.runStart == 49156 || current.runStart == 49166);
 }
 
-split {  
-    
+split
+{
     if (current.map == "11_KokuboSosho") {
         return (old.cutscene && !current.cutscene && current.soshoEnd);
     }
@@ -42,9 +45,10 @@ split {
         return false;
     }
 
-	return (current.map != old.map && current.map != "menu" && current.map != "01_Lighthouse");
+    return (current.map != old.map && current.map != "menu" && current.map != "01_Lighthouse");
 }
 
-reset {
+reset
+{
     return (old.ResetMenu != 0 && current.ResetMenu == 0 && current.map == "01_Lighthouse");
 }

--- a/SCCT_AutoSplitter.asl
+++ b/SCCT_AutoSplitter.asl
@@ -1,54 +1,142 @@
-// SCCT AutoSplitter by Distro
-// This current version is for testing purposes only. If it proves to work for everyone, there will be code cleanup.
-// Please leave some feedback on how well the autosplitter works and report bugs to Distro.
+// SCCT AutoSplitter by Distro and Buttercak3
 
 state("splintercell3")
 {
-    //Load Removal
-    bool isMenu: "splintercell3.exe", 0x8FA4E8, 0xF8; // Flag that tells you when we're in the menu. Only necessary if you use either LevelTime or LoadTime. Can also be used in the future if we want to pause the timer in menus.
-    bool cutscene: "binkw32.dll", 0x54AB4; // Flag that tells you when a cutscene is running. Only necessary if you use either LevelTime or LoadTime.
-    //int loadSave: "splintercell3.exe", 0x29A560, 0xC, 0x134; // set to 6 during QS or QL
-    int loadSave: "splintercell3.exe", 0xA16A08, 0xC, 0x134; // set to 6 during QS or QL
-    int levelLoad: "splintercell3.exe", 0x8C8B38; // used as flag because the value stays at 1 when loading a level.
+    // Load removal
+    bool cutscene: "binkw32.dll", 0x54AB4;
+    bool qsql: "splintercell3.exe", 0x9327E8;
+    int isLoading: "splintercell3.exe", 0x8C8B38;
 
-    //Splitting behavior
-    string255 map: "splintercell3.exe", 0x73E6CC, 0x4;
-    int ResetMenu: "splintercell3.exe",  0xA17608, 0x184; // Used for auto-reset. Turns to 0 when Press Fire to Load Screen is done loading on Lighthouse.
-    //int runStart: "splintercell3.exe",  0x1079F4, 0x94; // Used for auto-start. Jumps from 1 to 49155 or 49166 when run starts.
-    int runStart: "splintercell3.exe",  0x8F6988, 0x450, 0x9C, 0x10, 0x50, 0x820; // Used for auto-start. Jumps from 1 to 49155 or 49166 when run starts.
-    bool soshoEnd: "splintercell3.exe",  0x7497D4, 0x1C; // Last mission complete Flag 1
-    //bool missionComplete: "splintercell3.exe", 0xA2C81C; // 1 at mission complete
+    // Splitting behavior
+    int runStart: "splintercell3.exe", 0x8F6988, 0x450, 0x9C, 0x10, 0x50, 0x820;
+    string255 mapName: "splintercell3.exe", 0x73E6CC, 0x4;
+    int inResetMenu: "splintercell3.exe",  0xA17608, 0x184;
+    bool soshoEnd: "splintercell3.exe",  0x7497D4, 0x1C;
+    bool missionComplete: "splintercell3.exe", 0xA2C81C;
+
+    // In-game timer
+    double igt: "splintercell3.exe", 0x0090B734, 0x10, 0x14, 0x80;
 }
 
 startup
 {
-    settings.Add("subsplit", false, "Split when entering Seoul Part 2?");
+    settings.Add("subsplit", false, "Split when entering Seoul Part 2");
+    settings.Add("coop_mode", false, "[Experimental] Co-op mode");
+    settings.Add("sync_igt", false, "[Experimental] Sync Game Time with in-game timer");
+    settings.Add("actual_igt", false, "Always display the actual in-game time", "sync_igt");
+    settings.Add("il_mode", false, "[Experimental] IL Mode");
+    settings.Add("il_noql", false, "No QS/QL Mode", "il_mode");
+
+    settings.SetToolTip("actual_igt", "Game Time will go back down after a QL; Useful for practice and debugging");
+    settings.SetToolTip("il_mode", "Auto-start in every mission and split at the mission complete screen");
+    settings.SetToolTip("il_noql", "Auto-start after the loadout selection instead (use with IGT sync setting)");
+    settings.SetToolTip("coop_mode", "Auto-start when the IGT starts in any level");
+
+    // Tracks Game Time synced with the game
+    vars.gameTime = 0.0d;
+
+    // Used to track real-time whenever IGT is not available
+    vars.prevTime = DateTime.Now;
+    vars.time = DateTime.Now;
+
+    vars.inLevel = false;
+}
+
+update {
+    if (settings["sync_igt"]) {
+        vars.prevTime = vars.time;
+        vars.time = DateTime.Now;
+
+        if (!vars.inLevel && old.igt != current.igt && current.igt == 0) {
+            vars.inLevel = true;
+        }
+
+        if (vars.inLevel && !old.missionComplete && current.missionComplete) {
+            vars.inLevel = false;
+        }
+    }
 }
 
 isLoading
 {
-    return (current.loadSave == 6 || current.levelLoad == 1);
+    if (settings["sync_igt"]) {
+        // Returning a constant true value will prevent LiveSplit from interpolating Game Time between ticks.
+        return true;
+    } else {
+        return current.qsql || current.isLoading == 1;
+    }
 }
 
 start
 {
-    return (current.runStart == 49155 || current.runStart == 49156 || current.runStart == 49166);
+    if (settings["coop_mode"]) {
+        return old.igt != 0 && current.igt == 0;
+    } else if (settings["il_mode"]) {
+        if (settings["il_noql"]) {
+            // Start when the IGT resets to 0
+            return old.igt == 0 && current.igt != 0;
+        } else {
+            return !old.cutscene && current.cutscene;
+        }
+    } else if (current.runStart == 49155 || current.runStart == 49156 || current.runStart == 49166) {
+        vars.inLevel = false;
+        return true;
+    }
 }
 
 split
 {
-    if (current.map == "11_KokuboSosho") {
+    if (settings["coop_mode"] && current.mapName == "05_NuclearPlant") {
+        return !old.missionComplete && current.missionComplete;
+    }
+
+    if (settings["il_mode"] && settings["il_noql"]) {
+        if (!old.missionComplete && current.missionComplete) {
+            return true;
+        }
+    }
+
+    if (current.mapName == "11_KokuboSosho") {
         return (old.cutscene && !current.cutscene && current.soshoEnd);
     }
 
-    if (!settings["subsplit"] && current.map == "09_SeoulTwo") {
+    if (!settings["subsplit"] && current.mapName == "09_SeoulTwo") {
         return false;
     }
 
-    return (current.map != old.map && current.map != "menu" && current.map != "01_Lighthouse");
+    return (current.mapName != old.mapName && current.mapName != "menu" && current.mapName != "01_Lighthouse");
 }
 
 reset
 {
-    return (old.ResetMenu != 0 && current.ResetMenu == 0 && current.map == "01_Lighthouse");
+    if (!settings["il_mode"]) {
+        return (old.inResetMenu != 0 && current.inResetMenu == 0 && current.mapName == "01_Lighthouse");
+    }
+}
+
+gameTime
+{
+    if (!settings["sync_igt"]) {
+        return null;
+    } else if (settings["actual_igt"]) {
+        return TimeSpan.FromSeconds(current.igt);
+    } else if (current.isLoading == 1) {
+        return TimeSpan.FromSeconds(vars.gameTime);
+    } else if (!vars.inLevel || (current.igt == old.igt && !current.qsql)) {
+        // Whenever we're not playing, use real-time.
+        vars.gameTime += (vars.time - vars.prevTime).TotalMilliseconds / 1000.0;
+    } else if (current.igt >= old.igt + 2) {
+        // When the IGT does a large jump (more than 2 seconds), use real-time instead.
+        // This can happen between levels or when going to the menu.
+        vars.gameTime += (vars.time - vars.prevTime).TotalMilliseconds / 1000.0;
+    } else if (current.igt > old.igt) {
+        vars.gameTime += current.igt - old.igt;
+    }
+
+    return TimeSpan.FromSeconds(vars.gameTime);
+}
+
+onReset
+{
+    vars.gameTime = 0.0;
 }


### PR DESCRIPTION
This isn't done yet, but I decided to open this up so you can test everything. Here is a list of what I've done:

* Code clean-up
  * Consistent formatting
  * Renamed some variables to better reflect what they do
* Fixed an issue where the timer would immediately restart after a manual reset during a mission
* Added an IGT sync feature that links the Game Time in LiveSplit to the in-game timer

## IL Mode

IL mode has two settings, one for each of the speedrun categories ("QS/QL" and "No QS/QL"). It will split according to the current rules. For now that means that it will start a run whenever a cutscene starts.

I didn't extensively test the start trigger. Therefore, this feature is currently marked as "[Experimental]" in the settings.

## IGT synchronization

When the `sync_igt` setting is enabled, the Game Time in LiveSplit will run at the same speed as the in-game timer. When you load a quick-save, the timer **will not** revert back to the state of the save. It will instead keep running, but still at the same time as the IGT.

I implemented this feature because I suspect that the game slows down as a result of poor connection quality. A team with a better connection has an advantage over a team with lag. However, it could still be useful in singleplayer.

The timer has sub-second precision and practically perfect save/load removal. That means that if you play a level without quick-loads or opening the ESC menu, the time at the split will be precise to at least 2 decimal digits, even if you quick-saved several times during the run.

The `actual_igt` setting fully binds the LiveSplit Game Time to the in-game timer, meaning that the timer **will** revert to a previous state after a load. That means that, upon completion of a level, LiveSplit will show exactly what the in-game timer was at that time. This is useful for debugging and maybe for practice.

This is not (yet?) an official way to time a run in any category. Therefore, this feature is still marked as "[Experimental]" in the settings.

## Co-op mode

When the `coop_mode` setting is enabled, the timer will start on any level when the IGT starts. It does *not* automatically enable the IGT sync feature described above. It will only use the IGT to determine the start of the run. IGT syncing can additionally be enabled with its respective setting. The timer will split in the last co-op level on the "MISSION COMPLETE" screen.

I couldn't yet test this extensively because it's impossible to do alone. It's also not an official way to time a run in the co-op category. Therefore, this feature is still marked as "[Experimental]" in the settings.

## Things left to do
- [x] Check that the new addresses always work
- [x] Test the split action in the last mission of SP
- [x] Figure out a better way to structure the settings